### PR TITLE
Retry state file replace on permission errors

### DIFF
--- a/live_trader.py
+++ b/live_trader.py
@@ -217,7 +217,17 @@ def save_state(state: Dict) -> None:
         state["trades"] = state["trades"][-2000:]
     tmp = STATE_FILE.with_suffix(".tmp")
     tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp.replace(STATE_FILE)
+    max_attempts = 5
+    for attempt in range(max_attempts):
+        try:
+            tmp.replace(STATE_FILE)
+            break
+        except (PermissionError, OSError) as exc:
+            if attempt == max_attempts - 1:
+                print(f"[WARN] unable to persist state after {max_attempts} attempts: {exc}")
+                tmp.unlink(missing_ok=True)
+            else:
+                time.sleep(0.15)
 
 
 def load_thresholds() -> Optional[Dict[str, Dict[str, float]]]:


### PR DESCRIPTION
## Summary
- wrap the bot state file replace in retry logic to tolerate transient PermissionErrors
- log a warning and clean up the temp file if all attempts fail

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1407e2e7c83288415a5e9c39c8c42